### PR TITLE
buildscripts: do not rely on meson default prefix

### DIFF
--- a/buildscripts/buildall.sh
+++ b/buildscripts/buildall.sh
@@ -76,6 +76,7 @@ setup_prefix () {
 buildtype = 'release'
 default_library = 'static'
 wrap_mode = 'nodownload'
+prefix = '/usr/local'
 [binaries]
 c = '$CC'
 cpp = '$CXX'


### PR DESCRIPTION
In particular Homebrew has a crazy default here that breaks things, but there's no reason to rely on this either way.